### PR TITLE
Add docker-nuke script

### DIFF
--- a/docker-nuke
+++ b/docker-nuke
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker rm -f $(docker ps -aq)


### PR DESCRIPTION
Adds an initial script to indisciminately force kill all running Docker containers. This script could serve as a starting point, or inspiration, for additional Docker helper scripts.