### PR TITLE
Add docker-php script

### DIFF
--- a/docker-php
+++ b/docker-php
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+echo "----- Begin PHP Script -----"
+docker run --rm -v $(pwd)/$1:/script/$1 php:cli /bin/bash -c "php /script/$1; echo '';"
+echo "----- End PHP Script -----"


### PR DESCRIPTION
Adds a simple script to run any php file through the latest Docker `php-cli` container. This is useful for testing individual files against the current stable version of PHP.

Future updates could add options for selecting specific PHP versions, etc.