### PR TITLE
Add token-gen script

### DIFF
--- a/token-gen
+++ b/token-gen
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+cat /dev/urandom | tr -dc 'A-Z' | fold -w $1 | head -n 1


### PR DESCRIPTION
Adds a token-gen bash script, to generate a simple uppercase string token of a given size.
This is inspired by the following PHP script: https://gist.github.com/xdega/b007dadd352407f0ac75b2d40d372d42

Ideas for improvement would be to add a simple help file, or to add the ability to generate multiple keys as a second argument.